### PR TITLE
Added pkill command for mpv and xwinwrap

### DIFF
--- a/video-wallpaper.sh
+++ b/video-wallpaper.sh
@@ -30,9 +30,8 @@ update_config() {
 # Start video wallpaper playback
 start() {
 	# If there is an active video wallpaper, stop it first.
-	if [ ${#pid} -gt 0 ] ; then
-		stop
-	fi
+	pkill xwinwrap
+	pkill mpv
 	VIDEO_PATH="$1"
 	SCREENS=`xrandr | grep " connected\|\*" | pcregrep -o1 '([0-9]{1,}[x]{1,1}[0-9+]{1,}) \('`
 	for item in $SCREENS
@@ -43,12 +42,8 @@ start() {
 }
 
 stop() {
-	if [ ${#pid} -gt 0 ] ; then
-		echo "Stopping $name."
-		kill "$pid"
-	else
-		echo "No active video wallpaper found."
-	fi
+	pkill xwinwrap
+	pkill mpv
 	update_config
 }
 


### PR DESCRIPTION
Currently, the kill by pid doesn't seem to work. I don't know if my method of using pkill with the names of applications is better or not, but it does seem to work just fine. This makes sure that multiple instances of mpv and xwinwrap do not spawn, which was a problem earlier.